### PR TITLE
Add coverage for builtin filters

### DIFF
--- a/tests/Extension/BuiltinExtensionTest.js
+++ b/tests/Extension/BuiltinExtensionTest.js
@@ -3,6 +3,7 @@ import { render, equal } from '../util';
 const Environment = Kumis.Environment;
 const AbstractExtension = Kumis.Extension.AbstractExtension;
 const SafeString = Kumis.Util.SafeString;
+const TemplateError = Kumis.Exception.TemplateError;
 const TestCase = Jymfony.Component.Testing.Framework.TestCase;
 
 export default class BuiltinExtensionTest extends TestCase {
@@ -200,5 +201,146 @@ export default class BuiltinExtensionTest extends TestCase {
         }
         }
 
+    }
+
+    async testBuiltinFiltersProduceExpectedOutput() {
+        const env = Environment.create();
+
+        await equal(
+            '{% for row in [1, 2, 3, 4, 5] | batch(2, "X") %}[{{ row | join(",") }}]{% endfor %}',
+            '[1,2][3,4][5,X]',
+            env
+        );
+
+        await equal(
+            '{% for pair in mapping | dictsort %}{{ pair[0] }}={{ pair[1] }};{% endfor %}',
+            { mapping: { b: 2, a: 1 } },
+            'a=1;b=2;',
+            env
+        );
+
+        await equal(
+            '{{ "Foo Bar Baz" | replace("Bar", "Quux") }}',
+            'Foo Quux Baz',
+            env
+        );
+
+        await equal(
+            '{{ "Check https://example.com" | urlize }}',
+            'Check &lt;a href=&quot;https://example.com&quot;&gt;https://example.com&lt;/a&gt;',
+            env
+        );
+
+        await equal(
+            '{{ "Lorem ipsum dolor sit amet" | truncate(12) }}',
+            'Lorem ipsum...',
+            env
+        );
+
+        await equal(
+            '{{ [42] | random }}',
+            '42',
+            env
+        );
+
+        await equal(
+            '{{ [1, 2, 3] | sum }}',
+            '6',
+            env
+        );
+
+        await equal(
+            '{{ users | sum("age", 10) }}',
+            { users: [ { name: 'Ada', age: 32 }, { name: 'Linus', age: 28 } ] },
+            '70',
+            env
+        );
+
+        await equal(
+            '{% for row in [1, 2, 3, 4, 5] | slice(3, "X") %}[{{ row | join(",") }}]{% endfor %}',
+            '[1,2][3,4][5,X]',
+            env
+        );
+    }
+
+    async testBuiltinFiltersHandleSafeStringsAndCollections() {
+        const env = Environment.create();
+        const safe = new SafeString('<strong>Safe</strong>');
+
+        await equal(
+            '{{ safe | escape }}',
+            { safe },
+            '<strong>Safe</strong>',
+            env
+        );
+
+        await equal(
+            '{{ safe | forceescape }}',
+            { safe },
+            '&lt;strong&gt;Safe&lt;/strong&gt;',
+            env
+        );
+
+        await equal(
+            '{{ collection | length }}',
+            { collection: new Map([ [ 'a', 1 ], [ 'b', 2 ] ]) },
+            '2',
+            env
+        );
+
+        await equal(
+            '{% for entry in { first: 1, second: 2 } | list %}{{ entry.key }}={{ entry.value }};{% endfor %}',
+            'first=1;second=2;',
+            env
+        );
+    }
+
+    async testBuiltinFilterAliases() {
+        const env = Environment.create();
+
+        __self.assertTrue('function' === typeof env.getFilter('default'));
+        __self.assertTrue('function' === typeof env.getFilter('d'));
+        __self.assertTrue('function' === typeof env.getFilter('e'));
+
+        await this.assertThrows(() => env.getFilter('default_'), Error, /filter not found: default_/);
+    }
+
+    async testBuiltinFilterErrors() {
+        const env = Environment.create();
+
+        await this.assertThrows(
+            () => render('{{ value | dictsort }}', { value: 42 }, {}, env),
+            TemplateError,
+            /dictsort filter: val must be an object/
+        );
+
+        await this.assertThrows(
+            () => render('{{ value | list }}', { value: 42 }, {}, env),
+            TemplateError,
+            /list filter: type not iterable/
+        );
+    }
+
+    async assertThrows(executable, expected, messageRegex = undefined) {
+        let caught;
+
+        try {
+            const result = executable();
+            if (result && 'function' === typeof result.then) {
+                await result;
+            }
+        } catch (error) {
+            caught = error;
+        }
+
+        if (! caught) {
+            this.fail('Expected exception to be thrown.');
+        }
+
+        this.assertInstanceOf(expected, caught);
+
+        if (messageRegex) {
+            this.assertMatchesRegularExpression(messageRegex, String(caught));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend the builtin extension tests with focused coverage for the core filters and special cases
- verify filter alias exposure using Environment.getFilter lookups
- assert TemplateError is thrown for invalid inputs to dictsort and list

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e3d20501008333810eba110c90e46e